### PR TITLE
Leave null subsciption url unchanged

### DIFF
--- a/CRM/Core/Payment/Ewayrecurring.php
+++ b/CRM/Core/Payment/Ewayrecurring.php
@@ -549,7 +549,10 @@ class CRM_Core_Payment_Ewayrecurring extends CRM_Core_Payment
    */
   function subscriptionURL($entityID = NULL, $entity = NULL, $action = 'cancel') {
     $url = parent::subscriptionURL($entityID, $entity, $action);
-    if (!isset($url) || stristr($url, '&cs=')) {
+    if (!isset($url)) {
+      return NULL;
+    }
+    if (stristr($url, '&cs=')) {
       return $url;
     }
     $user_id = CRM_Core_Session::singleton()->get('userID');


### PR DESCRIPTION
Eileen, parent::subscriptionURL() can return NULL. This happens in the case of $action = 'billing'.

This PR prevents a 'cs=' query parameter being appended to a NULL URL. That will be included in the Contribution receipt and the donor will have a bad link in their receipt.
