### PR TITLE
Mark as completed a recurring contribution with 1 installment

### DIFF
--- a/CRM/Core/Payment/Ewayrecurring.php
+++ b/CRM/Core/Payment/Ewayrecurring.php
@@ -126,11 +126,17 @@ class CRM_Core_Payment_Ewayrecurring extends CRM_Core_Payment {
         $params['trxn_id'] = $initialPayment['values'][$managed_customer_id]['trxn_id'];
         $params['contribution_status_id'] = 1;
         $params['payment_status_id'] = 1;
+        // If there's only one installment, then the recurring contribution is now complete
+        if (isset($params['installments']) && $params['installments'] == 1) {
+          $status = CRM_Core_OptionGroup::getValue('contribution_status', 'Completed', 'name');
+        } else {
+          $status = CRM_Core_OptionGroup::getValue('contribution_status', 'In Progress', 'name');
+        }
         // Save the eWay customer token in the recurring contribution's processor_id field.
         civicrm_api3('contribution_recur', 'create', array_merge(array(
           'id' => $params['contributionRecurID'],
           'processor_id' => $managed_customer_id,
-          'contribution_status_id' => CRM_Core_OptionGroup::getValue('contribution_status', 'In Progress', 'name'),
+          'contribution_status_id' => $status,
           'next_sched_contribution_date' => CRM_Utils_Date::isoToMysql(
             date('Y-m-d 00:00:00', strtotime('+' . $params['frequency_interval'] . ' ' . $params['frequency_unit']))),
         ), $extra));


### PR DESCRIPTION
When a donor makes a recurring contribution with one installment, an initial payment is made and the recurring contribution is left 'In Progress'.

When the batch job runs it "shoots first and asks questions later" - another payment is made and then the recurring contribution is 'Completed'. The donor is charged a second time.

This PR checks the number of installments, and if it is '1' the recurring contribution is 'Completed'.