### PR TITLE
Don't implode errors (it's a string)

### DIFF
--- a/CRM/Core/Payment/Ewayrecurring.php
+++ b/CRM/Core/Payment/Ewayrecurring.php
@@ -717,7 +717,7 @@ class CRM_Core_Payment_Ewayrecurring extends CRM_Core_Payment {
     $eWAYResponse = json_decode($responseData);
 
     if (self::isError($eWAYResponse)) {
-      throw new CRM_Core_Exception("Error: [" . implode(',', $eWAYResponse->Errors) . "]");
+      throw new CRM_Core_Exception(ts("Transaction failure (%1)", array(1 => $eWAYResponse->Errors)));
     }
 
     $status = ($eWAYResponse->BeagleScore) ? ($eWAYResponse->ResponseMessage . ': ' . $eWAYResponse->BeagleScore) : $eWAYResponse->ResponseMessage;


### PR DESCRIPTION
eWAY returns a string in `$eWAYResponse->Errors`, using `implode()` means we won't get to see them. 

Also protects against malicious error codes :+1: 