### PR TITLE
Do not show a bazilion stars as the submitted CC number

### DIFF
--- a/js/EwayClientSide.js
+++ b/js/EwayClientSide.js
@@ -52,5 +52,3 @@ cj('#crm-main-content-wrapper form').submit(function() {
     encryptField(cj('#cvv2'), CRM.eway.ewayKey);
   }
 );
-
-

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -1,0 +1,302 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{if $action & 1024}
+    {include file="CRM/Contribute/Form/Contribution/PreviewHeader.tpl"}
+{/if}
+
+{include file="CRM/common/TrackingFields.tpl"}
+
+<div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-contribution-confirm-form-block">
+    <div id="help">
+        <p>{ts}Please verify the information below carefully. Click <strong>Go Back</strong> if you need to make changes.{/ts}
+            {if $contributeMode EQ 'notify' and ! $is_pay_later}
+                {if $paymentProcessor.payment_processor_type EQ 'Google_Checkout'}
+                    {ts}Click the <strong>Google Checkout</strong> button to checkout to Google, where you will select your payment method and complete the contribution.{/ts}
+                {else}
+                    {ts 1=$paymentProcessor.name 2=$button}Click the <strong>%2</strong> button to go to %1, where you will select your payment method and complete the contribution.{/ts}
+                {/if}
+            {elseif ! $is_monetary or $amount LE 0.0 or $is_pay_later}
+                {ts 1=$button}To complete this transaction, click the <strong>%1</strong> button below.{/ts}
+            {else}
+                {ts 1=$button}To complete your contribution, click the <strong>%1</strong> button below.{/ts}
+            {/if}
+        </p>
+    </div>
+    <div id="crm-submit-buttons" class="crm-submit-buttons">
+        {include file="CRM/common/formButtons.tpl" location="top"}
+    </div>
+    {if $is_pay_later}
+        <div class="bold pay_later_receipt-section">{$pay_later_receipt}</div>
+    {/if}
+
+    {include file="CRM/Contribute/Form/Contribution/MembershipBlock.tpl" context="confirmContribution"}
+
+    {if $amount GTE 0 OR $minimum_fee GTE 0 OR ( $priceSetID and $lineItem ) }
+    <div class="crm-group amount_display-group">
+       {if !$useForMember}
+        <div class="header-dark">
+            {if !$membershipBlock AND $amount OR ( $priceSetID and $lineItem ) }{ts}Contribution Amount{/ts}{else}{ts}Membership Fee{/ts} {/if}
+        </div>
+  {/if}
+        <div class="display-block">
+            {if !$useForMember}
+              {if $lineItem and $priceSetID}
+                {if !$amount}{assign var="amount" value=0}{/if}
+                {assign var="totalAmount" value=$amount}
+                {include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
+              {elseif $is_separate_payment }
+                {if $amount AND $minimum_fee}
+                    {$membership_name} {ts}Membership{/ts}: <strong>{$minimum_fee|crmMoney}</strong><br />
+                    {ts}Additional Contribution{/ts}: <strong>{$amount|crmMoney}</strong><br />
+                    <strong> -------------------------------------------</strong><br />
+                    {ts}Total{/ts}: <strong>{$amount+$minimum_fee|crmMoney}</strong><br />
+                {elseif $amount }
+                    {ts}Amount{/ts}: <strong>{$amount|crmMoney} {if $amount_level } - {$amount_level} {/if}</strong>
+                {else}
+                    {$membership_name} {ts}Membership{/ts}: <strong>{$minimum_fee|crmMoney}</strong>
+                {/if}
+              {else}
+                {if $totalTaxAmount }
+                     {ts}Total Tax Amount{/ts}: <strong>{$totalTaxAmount|crmMoney} </strong><br />
+                {/if}
+                {if $amount }
+                    {ts}Total Amount{/ts}: <strong>{$amount|crmMoney} {if $amount_level } - {$amount_level} {/if}</strong>
+                {else}
+                    {$membership_name} {ts}Membership{/ts}: <strong>{$minimum_fee|crmMoney}</strong>
+                {/if}
+              {/if}
+                {/if}
+
+            {if $is_recur}
+                {if !empty($auto_renew)} {* Auto-renew membership confirmation *}
+{crmRegion name="contribution-confirm-recur-membership"}
+                    <br />
+                    <strong>{ts 1=$frequency_interval 2=$frequency_unit}I want this membership to be renewed automatically every %1 %2(s).{/ts}</strong></p>
+                    <div class="description crm-auto-renew-cancel-info">({ts}Your initial membership fee will be processed once you complete the confirmation step. You will be able to cancel the auto-renewal option by visiting the web page link that will be included in your receipt.{/ts})</div>
+{/crmRegion}
+                {else}
+{crmRegion name="contribution-confirm-recur"}
+                    {if $installments}
+                      {if $frequency_interval > 1}
+                        <p><strong>{ts 1=$frequency_interval 2=$frequency_unit 3=$installments}I want to contribute this amount every %1 %2s for %3 installments.{/ts}</strong></p>
+                      {else}
+                        <p><strong>{ts 1=$frequency_unit 2=$installments}I want to contribute this amount every %1 for %2 installments.{/ts}</strong></p>
+                      {/if}
+                    {else}
+                      {if $frequency_interval > 1}
+                        <p><strong>{ts 1=$frequency_interval 2=$frequency_unit}I want to contribute this amount every %1 %2s.{/ts}</strong></p>
+                      {else}
+                        <p><strong>{ts 1=$frequency_unit }I want to contribute this amount every %1.{/ts}</strong></p>
+                      {/if}
+                    {/if}
+                    <p>{ts}Your initial contribution will be processed once you complete the confirmation step. You will be able to cancel the recurring contribution by visiting the web page link that will be included in your receipt.{/ts}</p>
+{/crmRegion}
+                {/if}
+            {/if}
+
+            {if $is_pledge }
+                {if $pledge_frequency_interval GT 1}
+                    <p><strong>{ts 1=$pledge_frequency_interval 2=$pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %1 %2s for %3 installments.{/ts}</strong></p>
+                {else}
+                    <p><strong>{ts 1=$pledge_frequency_interval 2=$pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %2 for %3 installments.{/ts}</strong></p>
+                {/if}
+                {if $is_pay_later}
+                    <p>{ts 1=$receiptFromEmail 2=$button}Click &quot;%2&quot; below to register your pledge. You will be able to modify or cancel future pledge payments at any time by logging in to your account or contacting us at %1.{/ts}</p>
+                {else}
+                    <p>{ts 1=$receiptFromEmail 2=$button}Your initial pledge payment will be processed when you click &quot;%2&quot; below. You will be able to modify or cancel future pledge payments at any time by logging in to your account or contacting us at %1.{/ts}</p>
+                {/if}
+            {/if}
+        </div>
+    </div>
+    {/if}
+
+    {if $honor_block_is_active}
+        <div class="crm-group honor_block-group">
+            <div class="header-dark">
+                {$soft_credit_type}
+            </div>
+            <div class="display-block">
+                <div class="label-left crm-section honoree_profile-section">
+                    <strong>{$honorName}</strong></br>
+                    {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields prefix='honor'}
+                </div>
+            </div>
+         </div>
+    {/if}
+
+    {if $customPre}
+      <fieldset class="label-left crm-profile-view">
+        {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
+      </fieldset>
+    {/if}
+
+    {if $pcpBlock}
+    <div class="crm-group pcp_display-group">
+        <div class="header-dark">
+            {ts}Contribution Honor Roll{/ts}
+        </div>
+        <div class="display-block">
+            {if $pcp_display_in_roll}
+                {ts}List my contribution{/ts}
+                {if $pcp_is_anonymous}
+                    <strong>{ts}anonymously{/ts}.</strong>
+                {else}
+        {ts}under the name{/ts}: <strong>{$pcp_roll_nickname}</strong><br/>
+                    {if $pcp_personal_note}
+                        {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
+                    {else}
+                     <strong>{ts}With no personal note{/ts}</strong>
+                     {/if}
+                {/if}
+            {else}
+                {ts}Don't list my contribution in the honor roll.{/ts}
+            {/if}
+            <br />
+        </div>
+    </div>
+    {/if}
+
+    {if $onbehalfProfile}
+      <div class="crm-group onBehalf_display-group label-left crm-profile-view">
+         {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf'}
+         <div class="crm-section organization_email-section">
+            <div class="label">{ts}Organization Email{/ts}</div>
+            <div class="content">{$onBehalfEmail}</div>
+            <div class="clear"></div>
+         </div>
+      </div>
+    {/if}
+
+    {if ( $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) ) or $email }
+        {if $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) }
+          {if $billingName or $address}
+            <div class="crm-group billing_name_address-group">
+                <div class="header-dark">
+                    {ts}Billing Name and Address{/ts}
+                </div>
+              <div class="crm-section no-label billing_name-section">
+                <div class="content">{$billingName}</div>
+                <div class="clear"></div>
+              </div>
+              <div class="crm-section no-label billing_address-section">
+                <div class="content">{$address|nl2br}</div>
+                <div class="clear"></div>
+              </div>
+             </div>
+          {/if}
+        {/if}
+        {if $email}
+            <div class="crm-group contributor_email-group">
+                <div class="header-dark">
+                    {ts}Your Email{/ts}
+                </div>
+                <div class="crm-section no-label contributor_email-section">
+                  <div class="content">{$email}</div>
+                  <div class="clear"></div>
+                </div>
+            </div>
+        {/if}
+    {/if}
+
+    {* Show credit or debit card section for 'direct' mode, except for PayPal Express (detected because credit card number is empty) *}
+    {if $contributeMode eq 'direct' and ! $is_pay_later and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 )}
+{crmRegion name="contribution-confirm-billing-block"}
+       {if ($credit_card_number or $bank_account_number)}
+        <div class="crm-group credit_card-group">
+            <div class="header-dark">
+            {if $paymentProcessor.payment_type & 2}
+                 {ts}Direct Debit Information{/ts}
+            {else}
+                {ts}Credit Card Information{/ts}
+            {/if}
+            </div>
+            {if $paymentProcessor.payment_type & 2}
+                <div class="display-block">
+                    {ts}Account Holder{/ts}: {$account_holder}<br />
+                    {ts}Bank Account Number{/ts}: {$bank_account_number}<br />
+                    {ts}Bank Identification Number{/ts}: {$bank_identification_number}<br />
+                    {ts}Bank Name{/ts}: {$bank_name}<br />
+                </div>
+                {if $contributeMode eq 'direct'}
+                  <div class="crm-group debit_agreement-group">
+                      <div class="header-dark">
+                          {ts}Agreement{/ts}
+                      </div>
+                      <div class="display-block">
+                          {ts}Your account data will be used to charge your bank account via direct debit. While submitting this form you agree to the charging of your bank account via direct debit.{/ts}
+                      </div>
+                  </div>
+                {/if}
+            {else}
+                <div class="crm-section no-label credit_card_details-section">
+                  <div class="content">{$credit_card_type}</div>
+                  <div class="content">{$credit_card_number}</div>
+                  <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+                  <div class="clear"></div>
+                </div>
+            {/if}
+        </div>
+      {/if}
+{/crmRegion}
+    {/if}
+
+    {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="confirmContribution"}
+
+    {if $customPost}
+      <fieldset class="label-left crm-profile-view">
+        {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
+      </fieldset>
+    {/if}
+
+    {if $contributeMode NEQ 'notify' and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) } {* In 'notify mode, contributor is taken to processor payment forms next *}
+    <div class="messages status continue_instructions-section">
+        <p>
+        {if $is_pay_later OR $amount LE 0.0}
+            {ts 1=$button}Your transaction will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.{/ts}
+        {else}
+            {ts 1=$button}Your contribution will not be completed until you click the <strong>%1</strong> button. Please click the button one time only.{/ts}
+        {/if}
+        </p>
+    </div>
+    {/if}
+
+    {if $paymentProcessor.payment_processor_type EQ 'Google_Checkout' and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) and ! $is_pay_later}
+        <fieldset class="crm-group google_checkout-group"><legend>{ts}Checkout with Google{/ts}</legend>
+        <table class="form-layout-compressed">
+            <tr>
+                <td class="description">{ts}Click the Google Checkout button to continue.{/ts}</td>
+            </tr>
+            <tr>
+                <td>{$form._qf_Confirm_next_checkout.html} <span style="font-size:11px; font-family: Arial, Verdana;">Checkout securely.  Pay without sharing your financial information. </span></td>
+            </tr>
+        </table>
+        </fieldset>
+    {/if}
+
+    <div id="crm-submit-buttons" class="crm-submit-buttons">
+        {include file="CRM/common/formButtons.tpl" location="bottom"}
+    </div>
+</div>

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -253,7 +253,7 @@
             {else}
                 <div class="crm-section no-label credit_card_details-section">
                   <div class="content">{$credit_card_type}</div>
-                  <div class="content">{$credit_card_number}</div>
+                  <div class="content">{if $credit_card_number|count_characters > 19}XXXX-XXXX-XXXX-XXXX{else}{$credit_card_number}{/if}</div>
                   <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
                   <div class="clear"></div>
                 </div>

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -1,0 +1,325 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{if $action & 1024}
+  {include file="CRM/Contribute/Form/Contribution/PreviewHeader.tpl"}
+{/if}
+
+{include file="CRM/common/TrackingFields.tpl"}
+
+<div class="crm-contribution-page-id-{$contributionPageID} crm-block crm-contribution-thankyou-form-block">
+  {if $thankyou_text}
+    <div id="thankyou_text" class="crm-section thankyou_text-section">
+      {$thankyou_text}
+    </div>
+  {/if}
+
+  {* Show link to Tell a Friend (CRM-2153) *}
+  {if $friendText}
+    <div id="tell-a-friend" class="crm-section friend_link-section">
+      <a href="{$friendURL}" title="{$friendText}" class="button"><span>&raquo; {$friendText}</span></a>
+    </div>{if !$linkText}<br /><br />{/if}
+  {/if}
+  {* Add button for donor to create their own Personal Campaign page *}
+  {if $linkText}
+    <div class="crm-section create_pcp_link-section">
+      <a href="{$linkTextUrl}" title="{$linkText}" class="button"><span>&raquo; {$linkText}</span></a>
+    </div><br /><br />
+  {/if}
+
+  <div id="help">
+    {* PayPal_Standard sets contribution_mode to 'notify'. We don't know if transaction is successful until we receive the IPN (payment notification) *}
+    {if $is_pay_later}
+      <div class="bold">{$pay_later_receipt}</div>
+      {if $is_email_receipt}
+        <div>
+          {if $onBehalfEmail AND ($onBehalfEmail neq $email)}
+            {ts 1=$email 2=$onBehalfEmail}An email confirmation with these payment instructions has been sent to %1 and to %2.{/ts}
+          {else}
+            {ts 1=$email}An email confirmation with these payment instructions has been sent to %1.{/ts}
+          {/if}
+        </div>
+      {/if}
+    {elseif $contributeMode EQ 'notify' OR ($contributeMode EQ 'direct' && $is_recur) }
+      <div>{ts 1=$paymentProcessor.name}Your contribution has been submitted to %1 for processing. Please print this page for your records.{/ts}</div>
+        {if $is_email_receipt}
+      <div>
+        {if $onBehalfEmail AND ($onBehalfEmail neq $email)}
+          {ts 1=$email 2=$onBehalfEmail}An email receipt will be sent to %1 and to %2 once the transaction is processed successfully.{/ts}
+        {else}
+          {ts 1=$email}An email receipt will be sent to %1 once the transaction is processed successfully.{/ts}
+        {/if}
+      </div>
+    {/if}
+  {else}
+    <div>{ts}Your transaction has been processed successfully. Please print this page for your records.{/ts}</div>
+      {if $is_email_receipt}
+        <div>
+          {if $onBehalfEmail AND ($onBehalfEmail neq $email)}
+            {ts 1=$email 2=$onBehalfEmail}An email receipt has also been sent to %1 and to %2{/ts}
+          {else}
+            {ts 1=$email}An email receipt has also been sent to %1{/ts}
+          {/if}
+        </div>
+      {/if}
+  {/if}
+  </div>
+  <div class="spacer"></div>
+
+  {include file="CRM/Contribute/Form/Contribution/MembershipBlock.tpl" context="thankContribution"}
+
+  {if $amount GTE 0 OR $minimum_fee GTE 0 OR ( $priceSetID and $lineItem ) }
+    <div class="crm-group amount_display-group">
+      {if !$useForMember}
+        <div class="header-dark">
+          {if !$membershipBlock AND $amount OR ( $priceSetID and $lineItem )}{ts}Contribution Information{/ts}{else}{ts}Membership Fee{/ts}{/if}
+        </div>
+      {/if}
+      <div class="display-block">
+        {if !$useForMember}
+          {if $lineItem and $priceSetID}
+            {if !$amount}{assign var="amount" value=0}{/if}
+            {assign var="totalAmount" value=$amount}
+            {include file="CRM/Price/Page/LineItem.tpl" context="Contribution"}
+          {elseif $membership_amount}
+            {$membership_name} {ts}Membership{/ts}: <strong>{$membership_amount|crmMoney}</strong><br />
+            {if $amount}
+              {if !$is_separate_payment}
+                {ts}Contribution Amount{/ts}: <strong>{$amount|crmMoney}</strong><br />
+              {else}
+                {ts}Additional Contribution{/ts}: <strong>{$amount|crmMoney}</strong><br />
+              {/if}
+            {/if}
+            <strong> -------------------------------------------</strong><br />
+            {ts}Total{/ts}: <strong>{$amount+$membership_amount|crmMoney}</strong><br />
+          {else}
+            {if $totalTaxAmount}
+              {ts}Tax Amount{/ts}: <strong>{$totalTaxAmount|crmMoney}</strong><br />
+            {/if}
+            {ts}Amount{/ts}: <strong>{$amount|crmMoney} {if $amount_level} - {$amount_level} {/if}</strong><br />
+          {/if}
+        {/if}
+        {if $receive_date}
+          {ts}Date{/ts}: <strong>{$receive_date|crmDate}</strong><br />
+        {/if}
+        {if $contributeMode ne 'notify' and $is_monetary and ! $is_pay_later and $trxn_id}
+          {ts}Transaction #{/ts}: {$trxn_id}<br />
+        {/if}
+        {if $membership_trx_id}
+          {ts}Membership Transaction #{/ts}: {$membership_trx_id}
+        {/if}
+
+        {* Recurring contribution / pledge information *}
+        {if $is_recur}
+          {if !empty($auto_renew)} {* Auto-renew membership confirmation *}
+            {crmRegion name="contribution-thankyou-recur-membership"}
+              <br />
+              {if $frequency_interval > 1}
+                <strong>{ts 1=$frequency_interval 2=$frequency_unit}This membership will be renewed automatically every %1 %2(s).{/ts}</strong>
+              {else}
+                <strong>{ts 1=$frequency_unit}This membership will be renewed automatically every %1.{/ts}</strong>
+              {/if}
+              <div class="description crm-auto-renew-cancel-info">({ts}You will receive an email receipt which includes information about how to cancel the auto-renewal option.{/ts})</div>
+            {/crmRegion}
+          {else}
+            {crmRegion name="contribution-thankyou-recur"}
+              {if $installments > 1}
+                {if $frequency_interval > 1}
+                  <p><strong>{ts 1=$frequency_interval 2=$frequency_unit 3=$installments}This recurring contribution will be automatically processed every %1 %2s for a total %3 installments (including this initial contribution).{/ts}</strong></p>
+                {else}
+                    <p><strong>{ts 1=$frequency_unit 2=$installments}This recurring contribution will be automatically processed every %1 for a total %2 installments (including this initial contribution).{/ts}</strong></p>
+                  {/if}
+                {else}
+                  {if $frequency_interval > 1}
+                    <p><strong>{ts 1=$frequency_interval 2=$frequency_unit}This recurring contribution will be automatically processed every %1 %2s.{/ts}</strong></p>
+                  {else}
+                    <p><strong>{ts 1=$frequency_unit}This recurring contribution will be automatically processed every %1.{/ts}</strong></p>
+                  {/if}
+                {/if}
+                  <p>
+                  {if $is_email_receipt}
+                    {ts}You will receive an email receipt which includes information about how to update or cancel this recurring contribution.{/ts}
+                  {/if}
+                </p>
+            {/crmRegion}
+          {/if}
+        {/if}
+
+        {if $is_pledge}
+          {if $pledge_frequency_interval GT 1}
+            <p><strong>{ts 1=$pledge_frequency_interval 2=$pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %1 %2s for %3 installments.{/ts}</strong></p>
+          {else}
+            <p><strong>{ts 1=$pledge_frequency_interval 2=$pledge_frequency_unit 3=$pledge_installments}I pledge to contribute this amount every %2 for %3 installments.{/ts}</strong></p>
+          {/if}
+          <p>
+            {if $is_pay_later}
+              {ts 1=$receiptFromEmail}We will record your initial pledge payment when we receive it from you. You will be able to modify or cancel future pledge payments at any time by logging in to your account or contacting us at %1.{/ts}
+            {else}
+              {ts 1=$receiptFromEmail}Your initial pledge payment has been processed. You will be able to modify or cancel future pledge payments at any time by contacting us at %1.{/ts}
+            {/if}
+            {if $max_reminders}
+              {ts 1=$initial_reminder_day}We will send you a payment reminder %1 days prior to each scheduled payment date. The reminder will include a link to a page where you can make your payment online.{/ts}
+            {/if}
+          </p>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
+  {if $honor_block_is_active}
+    <div class="crm-group honor_block-group">
+      <div class="header-dark">
+        {$soft_credit_type}
+      </div>
+      <div class="display-block">
+       <div class="label-left crm-section honoree_profile-section">
+          <strong>{$honorName}</strong></br>
+          {include file="CRM/UF/Form/Block.tpl" fields=$honoreeProfileFields prefix='honor'}
+        </div>
+      </div>
+   </div>
+  {/if}
+
+  {if $customPre}
+    <fieldset class="label-left crm-profile-view">
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPre}
+    </fieldset>
+  {/if}
+
+  {if $pcpBlock}
+    <div class="crm-group pcp_display-group">
+      <div class="header-dark">
+        {ts}Contribution Honor Roll{/ts}
+      </div>
+      <div class="display-block">
+        {if $pcp_display_in_roll}
+          {ts}List my contribution{/ts}
+          {if $pcp_is_anonymous}
+            <strong>{ts}anonymously{/ts}.</strong>
+          {else}
+            {ts}under the name{/ts}: <strong>{$pcp_roll_nickname}</strong><br/>
+            {if $pcp_personal_note}
+              {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
+            {else}
+              <strong>{ts}With no personal note{/ts}</strong>
+            {/if}
+          {/if}
+        {else}
+          {ts}Don't list my contribution in the honor roll.{/ts}
+        {/if}
+        <br />
+      </div>
+    </div>
+  {/if}
+
+  {if $onbehalfProfile}
+    <div class="crm-group onBehalf_display-group label-left crm-profile-view">
+      {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf'}
+      <div class="crm-section organization_email-section">
+        <div class="label">{ts}Organization Email{/ts}</div>
+        <div class="content">{$onBehalfEmail}</div>
+        <div class="clear"></div>
+       </div>
+    </div>
+  {/if}
+
+  {if ( $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) ) or $email }
+    {if $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 ) }
+      {if $billingName or $address}
+        <div class="crm-group billing_name_address-group">
+          <div class="header-dark">
+            {ts}Billing Name and Address{/ts}
+          </div>
+          <div class="crm-section no-label billing_name-section">
+            <div class="content">{$billingName}</div>
+            <div class="clear"></div>
+          </div>
+          <div class="crm-section no-label billing_address-section">
+            <div class="content">{$address|nl2br}</div>
+            <div class="clear"></div>
+          </div>
+        </div>
+      {/if}
+    {/if}
+    {if $email}
+      <div class="crm-group contributor_email-group">
+        <div class="header-dark">
+          {ts}Your Email{/ts}
+        </div>
+        <div class="crm-section no-label contributor_email-section">
+          <div class="content">{$email}</div>
+          <div class="clear"></div>
+        </div>
+      </div>
+    {/if}
+  {/if}
+
+  {if $contributeMode eq 'direct' and ! $is_pay_later and $is_monetary and ( $amount GT 0 OR $minimum_fee GT 0 )}
+    {crmRegion name="contribution-thankyou-billing-block"}
+      <div class="crm-group credit_card-group">
+        <div class="header-dark">
+          {if $paymentProcessor.payment_type & 2}
+            {ts}Direct Debit Information{/ts}
+          {else}
+            {ts}Credit Card Information{/ts}
+          {/if}
+        </div>
+        {if $paymentProcessor.payment_type & 2}
+          <div class="display-block">
+            {ts}Account Holder{/ts}: {$account_holder}<br />
+            {ts}Bank Identification Number{/ts}: {$bank_identification_number}<br />
+            {ts}Bank Name{/ts}: {$bank_name}<br />
+            {ts}Bank Account Number{/ts}: {$bank_account_number}<br />
+          </div>
+        {else}
+          <div class="crm-section no-label credit_card_details-section">
+            <div class="content">{$credit_card_type}</div>
+            <div class="content">{$credit_card_number}</div>
+            <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+            <div class="clear"></div>
+          </div>
+        {/if}
+      </div>
+    {/crmRegion}
+  {/if}
+
+  {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="thankContribution"}
+
+  {if $customPost}
+    <fieldset class="label-left crm-profile-view">
+      {include file="CRM/UF/Form/Block.tpl" fields=$customPost}
+    </fieldset>
+  {/if}
+
+  <div id="thankyou_footer" class="contribution_thankyou_footer-section">
+    <p>
+      {$thankyou_footer}
+    </p>
+  </div>
+  {if $isShare}
+    {capture assign=contributionUrl}{crmURL p='civicrm/contribute/transact' q="$qParams" a=1 fe=1 h=1}{/capture}
+    {include file="CRM/common/SocialNetwork.tpl" url=$contributionUrl title=$title pageURL=$contributionUrl}
+  {/if}
+</div>

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -296,7 +296,7 @@
         {else}
           <div class="crm-section no-label credit_card_details-section">
             <div class="content">{$credit_card_type}</div>
-            <div class="content">{$credit_card_number}</div>
+            <div class="content">{if $credit_card_number|count_characters > 19}XXXX-XXXX-XXXX-XXXX{else}{$credit_card_number}{/if}</div>
             <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
             <div class="clear"></div>
           </div>

--- a/templates/CRM/Contribute/Page/SubscriptionStatus.tpl
+++ b/templates/CRM/Contribute/Page/SubscriptionStatus.tpl
@@ -1,0 +1,59 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+
+{if $result eq true}
+  {if $task eq 'billing'}
+     {if $billingName}
+     <div class="crm-group billing_name_address-group">
+       <div class="header-dark">
+         {ts}Billing Name and Address{/ts}
+       </div>
+       <div class="crm-section no-label billing_name-section">
+       <div class="content">{$billingName}</div>
+         <div class="clear"></div>
+       </div>
+       <div class="crm-section no-label billing_address-section">
+         <div class="content">{$address|nl2br}</div>
+         <div class="clear"></div>
+       </div>
+     </div>
+     {/if}
+
+     {if $credit_card_number}
+     <div class="crm-group credit_card-group">
+       <div class="header-dark">
+         {ts}Credit Card Information{/ts}
+       </div>
+       <div class="crm-section no-label credit_card_details-section">
+         <div class="content">{$credit_card_type}</div>
+         <div class="content">{$credit_card_number}</div>
+         <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+         <div class="clear"></div>
+       </div>
+     </div>
+     {/if}
+  {/if}
+{/if}

--- a/templates/CRM/Contribute/Page/SubscriptionStatus.tpl
+++ b/templates/CRM/Contribute/Page/SubscriptionStatus.tpl
@@ -49,7 +49,7 @@
        </div>
        <div class="crm-section no-label credit_card_details-section">
          <div class="content">{$credit_card_type}</div>
-         <div class="content">{$credit_card_number}</div>
+         <div class="content">{if $credit_card_number|count_characters > 19}XXXX-XXXX-XXXX-XXXX{else}{$credit_card_number}{/if}</div>
          <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
          <div class="clear"></div>
        </div>

--- a/templates/CRM/Event/Cart/Form/Checkout/ThankYou.tpl
+++ b/templates/CRM/Event/Cart/Form/Checkout/ThankYou.tpl
@@ -1,0 +1,164 @@
+{include file="CRM/common/TrackingFields.tpl"}
+
+<div class="crm-block crm-event-thankyou-form-block">
+  <p>
+    {ts}This is your receipt of payment made for the following event registration.{/ts}
+  </p>
+  <p>
+    {ts 1=$transaction_id 2=$transaction_date|date_format:"%D %I:%M %p %Z"}Your order number is <strong>#%1</strong>. Please print this confirmation for your records. You will receieve a confirmation email with the information below.  Information about the workshops will be sent separately to each participant. Here's a summary of your transaction placed on %2:{/ts}
+  </p>
+  {if $pay_later_receipt && $is_pay_later}
+  <p>
+  {$pay_later_receipt}
+  </p>
+  {/if}
+  {if $payment_required}
+    <div class="crm-group billing_name_address-group">
+      <div class="header-dark">
+  {ts}Billing Name and Address{/ts}
+      </div>
+      <div class="crm-section no-label billing_name-section">
+    <div class="content">{$billing_name}</div>
+    <div class="clear"></div>
+      </div>
+      <div class="crm-section no-label billing_address-section">
+    <div class="content">
+      {$billing_street_address}<br/>
+      {$billing_city}, {$billing_state} {$billing_postal_code}
+    </div>
+    <div class="clear"></div>
+      </div>
+    </div>
+    {if $credit_card_type}
+      <div class="crm-group credit_card-group">
+        <div class="header-dark">
+                  {ts}Credit Card Information{/ts}
+        </div>
+        <div class="crm-section no-label credit_card_details-section">
+                  <div class="content">{$credit_card_type}</div>
+                  <div class="content">{$credit_card_number}</div>
+                  <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date.M}/{$credit_card_exp_date.Y}
+                    <div class="clear"></div>
+                  </div>
+        </div>
+      </div>
+    {/if}
+  {/if}
+  <table>
+    <thead>
+      <tr style="border-bottom: 1px solid #ccc">
+    <th class="event-title">
+      {ts}Event{/ts}
+    </th>
+    <th class="participants-column">
+      {ts}Participants{/ts}
+    </th>
+    <th class="cost">
+      {ts}Price{/ts}
+    </th>
+    <th class="amount">
+      {ts}Total{/ts}
+    </th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach from=$line_items item=line_item}
+      <tr class="event-line-item {$line_item.class}">
+    <td class="event-info">
+      <div class="event-title"><strong>{$line_item.event->title}</strong></div>
+      {if $line_item.event->is_show_location}
+        <div class="event-location">
+      {if $line_item.location.address.1.name}
+        {$line_item.location.address.1.name}
+      {/if}
+      {if $line_item.location.address.1.street_address}
+        {$line_item.location.address.1.street_address}
+      {/if}
+      {if $line_item.location.address.1.supplemental_address_1}
+        {$line_item.location.address.1.supplemental_address_1}
+      {/if}
+      {if $line_item.location.address.1.supplemental_address_2}
+        {$line_item.location.address.1.supplemental_address_2}
+      {/if}
+      {if $line_item.location.address.1.city}
+        {$line_item.location.address.1.city}, {$line_item.location.address.1.state_province} {$line_item.location.address.1.postal_code}
+      {/if}
+        </div>
+      {/if}{*End of isShowLocation condition*}
+      <div class="event-data">
+        {$line_item.event->start_date|date_format:"%D %I:%M %p"} -
+        {$line_item.event->end_date|date_format:"%I:%M %p"}
+      </div>
+    </td>
+    <td class="participants-column">
+      {$line_item.num_participants}<br />
+      {if $line_item.num_participants > 0}
+      <div class="participants" style="padding-left: 10px;">
+        {foreach from=$line_item.participants item=participant}
+          {$participant.display_name}<br />
+        {/foreach}
+      </div>
+      {/if}
+      {if $line_item.num_waiting_participants > 0}
+      {ts}Waitlisted:{/ts}<br/>
+      <div class="participants" style="padding-left: 10px;">
+        {foreach from=$line_item.waiting_participants item=participant}
+          {$participant.display_name}<br />
+        {/foreach}
+      </div>
+      {/if}
+    </td>
+    <td class="cost">
+      {$line_item.cost|crmMoney:$currency|string_format:"%10s"}
+    </td>
+    <td class="amount">
+      &nbsp;{$line_item.amount|crmMoney:$currency|string_format:"%10s"}
+    </td>
+      </tr>
+      {/foreach}
+    </tbody>
+    <tfoot>
+      {if $discounts}
+  <tr>
+    <td>
+    </td>
+    <td>
+    </td>
+    <td>
+      {ts}Subtotal{/ts}:
+    </td>
+    <td>
+      &nbsp;{$sub_total|crmMoney:$currency|string_format:"%10s"}
+    </td>
+  </tr>
+  {foreach from=$discounts key=myId item=i}
+    <tr>
+      <td>
+        {$i.title}
+      </td>
+      <td>
+      </td>
+      <td>
+      </td>
+      <td>
+        -{$i.amount|crmMoney:$currency|string_format:"%10s"}
+      </td>
+    </tr>
+  {/foreach}
+      {/if}
+      <tr>
+  <td>
+  </td>
+  <td>
+  </td>
+  <td class="total">
+    <strong>{ts}Total{/ts}:</strong>
+  </td>
+  <td class="total">
+    <strong>&nbsp;{$total|crmMoney:$currency|string_format:"%10s"}</strong>
+  </td>
+      </tr>
+    </tfoot>
+  </table>
+  <p>{ts}If you have questions about the status of your registration or purchase please contact us.{/ts}</p>
+</div>

--- a/templates/CRM/Event/Cart/Form/Checkout/ThankYou.tpl
+++ b/templates/CRM/Event/Cart/Form/Checkout/ThankYou.tpl
@@ -36,7 +36,7 @@
         </div>
         <div class="crm-section no-label credit_card_details-section">
                   <div class="content">{$credit_card_type}</div>
-                  <div class="content">{$credit_card_number}</div>
+                  <div class="content">{if $credit_card_number|count_characters > 19}XXXX-XXXX-XXXX-XXXX{else}{$credit_card_number}{/if}</div>
                   <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date.M}/{$credit_card_exp_date.Y}
                     <div class="clear"></div>
                   </div>

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -1,0 +1,221 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{if $action & 1024}
+    {include file="CRM/Event/Form/Registration/PreviewHeader.tpl"}
+{/if}
+
+{include file="CRM/common/TrackingFields.tpl"}
+
+<div class="crm-event-id-{$event.id} crm-block crm-event-confirm-form-block">
+    {if $isOnWaitlist}
+        <div class="help">
+            {ts}Please verify the information below. <span class="bold">Then click 'Continue' to be added to the WAIT LIST for this event</span>. If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
+        </div>
+    {elseif $isRequireApproval}
+        <div class="help">
+            {ts}Please verify the information below. Then click 'Continue' to submit your registration. <span class="bold">Once approved, you will receive an email with a link to a web page where you can complete the registration process.</span>{/ts}
+        </div>
+    {else}
+        <div id="help">
+        {ts}Please verify the information below. Click the <strong>Go Back</strong> button below if you need to make changes.{/ts}
+        {if $contributeMode EQ 'notify' and !$is_pay_later and ! $isAmountzero }
+            {if $paymentProcessor.payment_processor_type EQ 'Google_Checkout'}
+                {ts 1=$paymentProcessor.name}Click the <strong>%1</strong> button to checkout to Google, where you will select your payment method and complete the registration.{/ts}
+            {else}
+                {ts 1=$paymentProcessor.name}Click the <strong>Continue</strong> button to checkout to %1, where you will select your payment method and complete the registration.{/ts}
+            {/if }
+        {else}
+            {ts}Otherwise, click the <strong>Continue</strong> button below to complete your registration.{/ts}
+        {/if}
+        </div>
+        {if $is_pay_later and !$isAmountzero}
+            <div class="bold">{$pay_later_receipt}</div>
+        {/if}
+    {/if}
+
+    <div id="crm-submit-buttons" class="crm-submit-buttons">
+      {include file="CRM/common/formButtons.tpl" location="top"}
+    </div>
+
+    {if $event.confirm_text}
+        <div id="intro_text" class="crm-section event_confirm_text-section">
+          <p>{$event.confirm_text}</p>
+        </div>
+    {/if}
+
+    <div class="crm-group event_info-group">
+        <div class="header-dark">
+            {ts}Event Information{/ts}
+        </div>
+        <div class="display-block">
+            {include file="CRM/Event/Form/Registration/EventInfoBlock.tpl"}
+        </div>
+    </div>
+
+    {if $pcpBlock}
+    <div class="crm-group pcp_display-group">
+        <div class="header-dark">
+           {ts}Contribution Honor Roll{/ts}
+        </div>
+        <div class="display-block">
+            {if $pcp_display_in_roll}
+                {ts}List my contribution{/ts}
+                {if $pcp_is_anonymous}
+                    <strong>{ts}anonymously{/ts}.</strong>
+                {else}
+            {ts}under the name{/ts}: <strong>{$pcp_roll_nickname}</strong><br/>
+                    {if $pcp_personal_note}
+                        {ts}With the personal note{/ts}: <strong>{$pcp_personal_note}</strong>
+                    {else}
+                     <strong>{ts}With no personal note{/ts}</strong>
+                     {/if}
+                {/if}
+            {else}
+                {ts}Don't list my contribution in the honor roll.{/ts}
+            {/if}
+            <br />
+        </div>
+    </div>
+    {/if}
+
+    {if $paidEvent && !$isRequireApproval && !$isOnWaitlist}
+        <div class="crm-group event_fees-group">
+            <div class="header-dark">
+                {$event.fee_label}
+            </div>
+            {if $lineItem}
+                {include file="CRM/Price/Page/LineItem.tpl" context="Event"}
+            {elseif $amounts || $amount == 0}
+          <div class="crm-section no-label amount-item-section">
+                    {foreach from= $amounts item=amount key=level}
+              <div class="content">
+                  {$amount.amount|crmMoney}&nbsp;&nbsp;{$amount.label}
+              </div>
+                  <div class="clear"></div>
+                    {/foreach}
+            </div>
+                {if $totalTaxAmount}
+                  <div class="crm-section no-label total-amount-section">
+                  <div class="content bold">{ts}Total Tax Amount{/ts}:&nbsp;&nbsp;{$totalTaxAmount|crmMoney}</div>
+                  <div class="clear"></div>
+                  </div>
+                {/if}
+                {if $totalAmount}
+                <div class="crm-section no-label total-amount-section">
+                    <div class="content bold">{ts}Total Amount{/ts}:&nbsp;&nbsp;{$totalAmount|crmMoney}</div>
+                    <div class="clear"></div>
+                  </div>
+                {/if}
+                {if $hookDiscount.message}
+                    <div class="crm-section hookDiscount-section">
+                        <em>({$hookDiscount.message})</em>
+                    </div>
+                {/if}
+            {/if}
+
+        </div>
+    {/if}
+
+    {if $event.participant_role neq 'Attendee' and $defaultRole}
+        <div class="crm-group participant_role-group">
+            <div class="header-dark">
+                {ts}Participant Role{/ts}
+            </div>
+            <div class="crm-section no-label participant_role-section">
+                <div class="content">
+                    {$event.participant_role}
+                </div>
+              <div class="clear"></div>
+            </div>
+        </div>
+    {/if}
+
+    {include file="CRM/Event/Form/Registration/DisplayProfile.tpl"}
+
+    {if $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $paidEvent and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+      <div class="crm-group billing_name_address-group">
+            <div class="header-dark">
+                {ts}Billing Name and Address{/ts}
+            </div>
+          <div class="crm-section no-label billing_name-section">
+            <div class="content">{$billingName}</div>
+            <div class="clear"></div>
+          </div>
+          <div class="crm-section no-label billing_address-section">
+            <div class="content">{$address|nl2br}</div>
+            <div class="clear"></div>
+          </div>
+      </div>
+    {/if}
+
+    {if $contributeMode eq 'direct' and ! $is_pay_later and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+        <div class="crm-group credit_card-group">
+            <div class="header-dark">
+                {ts}Credit Card Information{/ts}
+            </div>
+            <div class="crm-section no-label credit_card_details-section">
+                <div class="content">{$credit_card_type}</div>
+            <div class="content">{$credit_card_number}</div>
+            <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+            <div class="clear"></div>
+          </div>
+        </div>
+    {/if}
+
+    {if $contributeMode NEQ 'notify'} {* In 'notify mode, contributor is taken to processor payment forms next *}
+    <div class="messages status section continue_message-section">
+        <p>
+        {ts}Your registration will not be submitted until you click the <strong>Continue</strong> button. Please click the button one time only. If you need to change any details, click the Go Back button below to return to the previous screen.{/ts}
+        </p>
+    </div>
+    {/if}
+
+    {if $paymentProcessor.payment_processor_type EQ 'Google_Checkout' and $paidEvent and !$is_pay_later and ! $isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+        <fieldset><legend>{ts}Checkout with Google{/ts}</legend>
+            <div class="crm-section google_checkout-section">
+                <table class="form-layout-compressed">
+                  <tr>
+                    <td class="description">{ts}Click the Google Checkout button to continue.{/ts}</td>
+                  </tr>
+                  <tr>
+                    <td>{$form._qf_Confirm_next_checkout.html} <span style="font-size:11px; font-family: Arial, Verdana;">Checkout securely.  Pay without sharing your financial information. </span></td>
+                  </tr>
+                </table>
+            </div>
+        </fieldset>
+    {/if}
+
+    <div id="crm-submit-buttons" class="crm-submit-buttons">
+      {include file="CRM/common/formButtons.tpl" location="bottom"}
+    </div>
+
+    {if $event.confirm_footer_text}
+        <div id="footer_text" class="crm-section event_confirm_footer-section">
+            <p>{$event.confirm_footer_text}</p>
+        </div>
+    {/if}
+</div>
+{include file="CRM/common/showHide.tpl"}

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -178,7 +178,7 @@
             </div>
             <div class="crm-section no-label credit_card_details-section">
                 <div class="content">{$credit_card_type}</div>
-            <div class="content">{$credit_card_number}</div>
+            <div class="content">{if $credit_card_number|count_characters > 19}XXXX-XXXX-XXXX-XXXX{else}{$credit_card_number}{/if}</div>
             <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
             <div class="clear"></div>
           </div>

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -1,0 +1,222 @@
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+{if $action & 1024}
+    {include file="CRM/Event/Form/Registration/PreviewHeader.tpl"}
+{/if}
+
+{include file="CRM/common/TrackingFields.tpl"}
+
+<div class="crm-event-id-{$event.id} crm-block crm-event-thankyou-form-block">
+    {* Don't use "normal" thank-you message for Waitlist and Approval Required registrations - since it will probably not make sense for those situations. dgg *}
+    {if $event.thankyou_text AND (not $isOnWaitlist AND not $isRequireApproval)}
+        <div id="intro_text" class="crm-section event_thankyou_text-section">
+            <p>
+            {$event.thankyou_text}
+            </p>
+        </div>
+    {/if}
+
+    {* Show link to Tell a Friend (CRM-2153) *}
+    {if $friendText}
+        <div id="tell-a-friend" class="crm-section tell_friend_link-section">
+            <a href="{$friendURL}" title="{$friendText}" class="button"><span>&raquo; {$friendText}</span></a>
+       </div><br /><br />
+    {/if}
+
+    {* Add button for donor to create their own Personal Campaign page *}
+    {if $pcpLink}
+      <div class="crm-section create_pcp_link-section">
+            <a href="{$pcpLink}" title="{$pcpLinkText}" class="button"><span>&raquo; {$pcpLinkText}</span></a>
+        </div><br /><br />
+    {/if}
+
+    <div id="help">
+        {if $isOnWaitlist}
+            <p>
+                <span class="bold">{ts}You have been added to the WAIT LIST for this event.{/ts}</span>
+                {ts}If space becomes available you will receive an email with a link to a web page where you can complete your registration.{/ts}
+             </p>
+        {elseif $isRequireApproval}
+            <p>
+                <span class="bold">{ts}Your registration has been submitted.{/ts}
+                {ts}Once your registration has been reviewed, you will receive an email with a link to a web page where you can complete the registration process.{/ts}</span>
+            </p>
+        {elseif $is_pay_later and $paidEvent and !$isAmountzero}
+            <div class="bold">{$pay_later_receipt}</div>
+            {if $is_email_confirm}
+                <p>{ts 1=$email}An email with event details has been sent to %1.{/ts}</p>
+            {/if}
+        {* PayPal_Standard sets contribution_mode to 'notify'. We don't know if transaction is successful until we receive the IPN (payment notification) *}
+        {elseif $contributeMode EQ 'notify' and $paidEvent}
+            <p>{ts 1=$paymentProcessor.name}Your registration payment has been submitted to %1 for processing. Please print this page for your records.{/ts}</p>
+            {if $is_email_confirm}
+                <p>{ts 1=$email}A registration confirmation email will be sent to %1 once the transaction is processed successfully.{/ts}</p>
+            {/if}
+        {else}
+            <p>{ts}Your registration has been processed successfully. Please print this page for your records.{/ts}</p>
+            {if $is_email_confirm}
+                <p>{ts 1=$email}A registration confirmation email has also been sent to %1{/ts}</p>
+            {/if}
+        {/if}
+    </div>
+    <div class="spacer"></div>
+
+    <div class="crm-group event_info-group">
+        <div class="header-dark">
+            {ts}Event Information{/ts}
+        </div>
+        <div class="display-block">
+            {include file="CRM/Event/Form/Registration/EventInfoBlock.tpl" context="ThankYou"}
+        </div>
+    </div>
+
+    {if $paidEvent && !$isRequireApproval && !$isOnWaitlist}
+        <div class="crm-group event_fees-group">
+            <div class="header-dark">
+                {$event.fee_label}
+            </div>
+            {if $lineItem}
+                {include file="CRM/Price/Page/LineItem.tpl" context="Event"}
+            {elseif $amount || $amount == 0}
+              <div class="crm-section no-label amount-item-section">
+                    {foreach from= $finalAmount item=amount key=level}
+                  <div class="content">
+                      {$amount.amount|crmMoney}&nbsp;&nbsp;{$amount.label}
+                  </div>
+                  <div class="clear"></div>
+                    {/foreach}
+                </div>
+                {if $totalTaxAmount}
+                  <div class="content bold">{ts}Tax Total{/ts}:&nbsp;&nbsp;{$totalTaxAmount|crmMoney}</div>
+                  <div class="clear"></div>
+                {/if}
+                {if $totalAmount}
+                 <div class="crm-section no-label total-amount-section">
+                    <div class="content bold">{ts}Event Total{/ts}:&nbsp;&nbsp;{$totalAmount|crmMoney}</div>
+                    <div class="clear"></div>
+                  </div>
+
+                    {if $hookDiscount.message}
+                        <div class="crm-section hookDiscount-section">
+                            <em>({$hookDiscount.message})</em>
+                        </div>
+                    {/if}
+                {/if}
+            {/if}
+
+            {if $receive_date}
+                <div class="crm-section no-label receive_date-section">
+                    <div class="content bold">{ts}Transaction Date{/ts}: {$receive_date|crmDate}</div>
+                  <div class="clear"></div>
+                </div>
+            {/if}
+            {if $contributeMode ne 'notify' AND $trxn_id}
+                <div class="crm-section no-label trxn_id-section">
+                    <div class="content bold">{ts}Transaction #{/ts}: {$trxn_id}</div>
+                <div class="clear"></div>
+              </div>
+            {/if}
+        </div>
+
+    {elseif $participantInfo}
+        <div class="crm-group participantInfo-group">
+            <div class="header-dark">
+                {ts}Additional Participant Email(s){/ts}
+            </div>
+            <div class="crm-section no-label participant_info-section">
+                <div class="content">
+                    {foreach from=$participantInfo  item=mail key=no}
+                        <strong>{$mail}</strong><br />
+                    {/foreach}
+                </div>
+            <div class="clear"></div>
+          </div>
+        </div>
+    {/if}
+
+    {if $event.participant_role neq 'Attendee' and $defaultRole}
+        <div class="crm-group participant_role-group">
+            <div class="header-dark">
+                {ts}Participant Role{/ts}
+            </div>
+            <div class="crm-section no-label participant_role-section">
+                <div class="content">
+                    {$event.participant_role}
+                </div>
+            <div class="clear"></div>
+          </div>
+        </div>
+    {/if}
+
+    {include file="CRM/Event/Form/Registration/DisplayProfile.tpl"}
+    {if $contributeMode ne 'notify' and (!$is_pay_later or $isBillingAddressRequiredForPayLater) and $paidEvent and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+        <div class="crm-group billing_name_address-group">
+            <div class="header-dark">
+                {ts}Billing Name and Address{/ts}
+            </div>
+          <div class="crm-section no-label billing_name-section">
+            <div class="content">{$billingName}</div>
+            <div class="clear"></div>
+          </div>
+          <div class="crm-section no-label billing_address-section">
+            <div class="content">{$address|nl2br}</div>
+            <div class="clear"></div>
+          </div>
+        </div>
+    {/if}
+
+    {if $contributeMode eq 'direct' and $paidEvent and ! $is_pay_later and !$isAmountzero and !$isOnWaitlist and !$isRequireApproval}
+        <div class="crm-group credit_card-group">
+            <div class="header-dark">
+                {ts}Credit Card Information{/ts}
+            </div>
+            <div class="crm-section no-label credit_card_details-section">
+                <div class="content">{$credit_card_type}</div>
+            <div class="content">{$credit_card_number}</div>
+            <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
+            <div class="clear"></div>
+          </div>
+        </div>
+    {/if}
+
+    {if $event.thankyou_footer_text}
+        <div id="footer_text" class="crm-section event_thankyou_footer-section">
+            <p>{$event.thankyou_footer_text}</p>
+        </div>
+    {/if}
+
+    <div class="action-link section event_info_link-section">
+        <a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.id`"}">&raquo; {ts 1=$event.event_title}Back to "%1" event information{/ts}</a>
+    </div>
+
+    {if $event.is_public }
+        {include file="CRM/Event/Page/iCalLinks.tpl"}
+    {/if}
+    {if $event.is_share}
+    {capture assign=eventUrl}{crmURL p='civicrm/event/info' q="id=`$event.id`&amp;reset=1" a=1 fe=1 h=1}{/capture}
+    {include file="CRM/common/SocialNetwork.tpl" url=$eventUrl title=$event.title pageURL=$eventUrl}
+    {/if}
+</div>

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -195,7 +195,7 @@
             </div>
             <div class="crm-section no-label credit_card_details-section">
                 <div class="content">{$credit_card_type}</div>
-            <div class="content">{$credit_card_number}</div>
+            <div class="content">{if $credit_card_number|count_characters > 19}XXXX-XXXX-XXXX-XXXX{else}{$credit_card_number}{/if}</div>
             <div class="content">{ts}Expires{/ts}: {$credit_card_exp_date|truncate:7:''|crmDate}</div>
             <div class="clear"></div>
           </div>


### PR DESCRIPTION
CiviCRM obfuscates the CC by hiding all but the last four numbers.

When the whole CC field has been encrypted and is a big blob of garbage, this looks ridiculous.

I didn't see a way to get CiviCRM hooks to modify variables for Smarty on these forms, so I just modified the templates. This is a bit shit since it creates problems for people who are customising those templates already, so a hook would be better ...

Should `hook_buildForm` or `hook_alterContent` have let me do this? Neither seemed to - I had access to the variables but changing them didn't modify the page output. Was also concerned that using buildform might prevent the values getting submitted eg on confirm page.
