### PR TITLE
Make client-side encryption work with AJAX snippets

### DIFF
--- a/CRM/Core/Payment/Ewayrecurring.php
+++ b/CRM/Core/Payment/Ewayrecurring.php
@@ -75,10 +75,11 @@ class CRM_Core_Payment_Ewayrecurring extends CRM_Core_Payment {
    */
   public function buildForm(&$form) {
     if (!empty($this->_paymentProcessor['signature'])) {
-      CRM_Core_Resources::singleton()->addSetting(array('eway' => array('ewayKey' => $this->_paymentProcessor['signature'])))
-      ->addScriptFile('com.chrischinchilla.ewayrecurring', 'js/EwayClientSide.js', 5, 'page-footer')
+      $region = CRM_Core_Resources::isAjaxMode() ? 'ajax-snippet' : 'page-footer';
+      CRM_Core_Resources::singleton()->addSetting(array('eway' => array('ewayKey' => $this->_paymentProcessor['signature'], 'formSelector' => (CRM_Core_Resources::isAjaxMode() ? '.crm-ajax-container form' : '#crm-main-content-wrapper form'))))
+      ->addScriptFile('com.chrischinchilla.ewayrecurring', 'js/EwayClientSide.js', 5, $region)
       //->addScriptUrl('https://secure.ewaypayments.com/scripts/eCrypt.debug.js', 1, 'page-footer');
-       ->addScriptUrl('https://secure.ewaypayments.com/scripts/eCrypt.js', 10, 'page-footer');
+       ->addScriptUrl('https://secure.ewaypayments.com/scripts/eCrypt.js', 10, $region);
     }
     return FALSE;
   }

--- a/js/EwayClientSide.js
+++ b/js/EwayClientSide.js
@@ -50,7 +50,7 @@ function isFieldEncrypted(field) {
 hideEncryptedFields(cj('#credit_card_number'));
 hideEncryptedFields(cj('#cvv2'));
 
-cj('#crm-main-content-wrapper form').submit(function() {
+cj(CRM.eway.formSelector).submit(function() {
     encryptField(cj('#credit_card_number'), CRM.eway.ewayKey);
     encryptField(cj('#cvv2'), CRM.eway.ewayKey);
   }


### PR DESCRIPTION
Payment processor would not work with backend process when AJAX pop-ups were enabled.
Amended to check if in AJAX mode to ensure scripts are added appropriately and the form submit handler is attached.